### PR TITLE
fixed the edge case where the agent go forward but there is no navigable locations to go

### DIFF
--- a/src/lib/MatterSim.cpp
+++ b/src/lib/MatterSim.cpp
@@ -470,12 +470,14 @@ void Simulator::renderScene() {
 void Simulator::makeAction(int index, double heading, double elevation) {
     totalTimer.Start();
     // move
-    if (!initialized || index < 0 || index >= state->navigableLocations.size() ){
+    if (!initialized || index < 0 || (state->navigableLocations.size() > 1 && index >= state->navigableLocations.size()) ){
         std::stringstream msg;
         msg << "MatterSim: Invalid action index: " << index;
         throw std::domain_error( msg.str() );
     }
-    state->location = state->navigableLocations[index];
+    if (state->navigableLocations.size() > 1) { // if there is any navigable locations, then just go; otherwise just stay
+        state->location = state->navigableLocations[index];
+    }
     state->location->rel_heading = 0.0;
     state->location->rel_elevation = 0.0;
     state->location->rel_distance = 0.0;


### PR DESCRIPTION
Hi @peteanderson80,

The error "ValueError: MatterSim: Invalid action index: 1" occurs sometimes during training.
I suspect this is a bug in the C++ code of your simulator. Say if the action is `forward`, then the corresponding `env action` is (1, 0, 0), whose index is 1. Combining with you following c++ code:
```
void Simulator::makeAction(int index, double heading, double elevation) {
    totalTimer.Start();
    // move
    if (!initialized || index < 0 || index >= state->navigableLocations.size() ){
        std::stringstream msg;
        msg << "MatterSim: Invalid action index: " << index;
        throw std::domain_error( msg.str() );
    }
```
Then it basically means that the agent always chooses the navigable location whose index is 1. So if the size is less than or equal 1, then it raises the error. This seems an edge case (the agent chooses to go forward but there is no next navigable location to go).

So my fix is to just stay in the same location if there is no next location to go and the agent still choose to go forward. 