### PR TITLE
Add support for HPC/Multiple GPU Devices with Limited Access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 *.zip
 /tasks/R2R/data/*.json
 /tasks/R2R/data/*_vocab.txt
+.idea/

--- a/include/MatterSim.hpp
+++ b/include/MatterSim.hpp
@@ -16,6 +16,7 @@
 #elif defined (EGL_RENDERING)
 #include <epoxy/gl.h>
 #include <EGL/egl.h>
+#include <EGL/eglext.h>
 #else
 #include <GL/glew.h>
 #endif

--- a/include/MatterSim.hpp
+++ b/include/MatterSim.hpp
@@ -15,6 +15,7 @@
 #include <GL/osmesa.h>
 #elif defined (EGL_RENDERING)
 #include <epoxy/gl.h>
+#define EGL_EGLEXT_PROTOTYPES
 #include <EGL/egl.h>
 #include <EGL/eglext.h>
 #else

--- a/src/lib/MatterSim.cpp
+++ b/src/lib/MatterSim.cpp
@@ -177,7 +177,7 @@ void Simulator::initialize() {
         // Assuming Nodes have no more than 32 GPUs
         const int maxDevices = 32;
         int validDevice = 0;
-        EGLDeviceExt eglDevices[maxDevices];
+        EGLDeviceEXT eglDevices[maxDevices];
         EGLint numDevices = 0;
 
         // Use EGL Helpers to return # of Valid Devices

--- a/src/lib/MatterSim.cpp
+++ b/src/lib/MatterSim.cpp
@@ -193,6 +193,8 @@ void Simulator::initialize() {
         int validDevice = 0;
         EGLDeviceEXT eglDevices[maxDevices];
         EGLint numDevices = 0;
+        EGLBoolean initialized;
+        EGLint major, minor;
 
         // Use EGL Helpers to return # of Valid Devices
         if (!eglQueryDevicesEXT(maxDevices, eglDevices, &numDevices) || eglGetError() != EGL_SUCCESS) {
@@ -206,17 +208,16 @@ void Simulator::initialize() {
 
             // Validate and Break
             if (eglGetError() == EGL_SUCCESS && eglDpy != EGL_NO_DISPLAY) {
-                break;
+                assertEGLError("eglGetDisplay");
+
+                // Initialize EGL and Check?
+                initialized = eglInitialize(eglDpy, &major, &minor);
+                if (eglGetError() == EGL_SUCCESS && initialized == EGL_TRUE) {
+                    assertEGLError("eglInitialize");
+                    break;
+                }
             }
         }
-
-        // Initialize EGL
-        assertEGLError("eglGetDisplay");
-
-        EGLint major, minor;
-
-        eglInitialize(eglDpy, &major, &minor);
-        assertEGLError("eglInitialize");
 
         // Select an appropriate configuration
         EGLint numConfigs;

--- a/src/lib/MatterSim.cpp
+++ b/src/lib/MatterSim.cpp
@@ -174,6 +174,20 @@ void Simulator::initialize() {
             throw std::runtime_error( "MatterSim: OSMesaMakeCurrent failed" );
         }
 #elif defined (EGL_RENDERING)
+        // Magic Linking Code?
+        PFNEGLQUERYDEVICESEXTPROC eglQueryDevicesEXT =
+                (PFNEGLQUERYDEVICESEXTPROC) eglGetProcAddress("eglQueryDevicesEXT");
+
+        if (!eglQueryDevicesEXT) {
+            throw std::runtime_error( "MatterSim: Extension eglQueryDevicesEXT not available" );
+        }
+
+        PFNEGLGETPLATFORMDISPLAYEXTPROC eglGetPlatformDisplayEXT =
+                (PFNEGLGETPLATFORMDISPLAYEXTPROC)eglGetProcAddress("eglGetPlatformDisplayEXT");
+        if (!eglGetPlatformDisplayEXT) {
+            throw std::runtime_error( "MatterSim: Extension eglGetPlatformDisplayEXT not available" );
+        }
+
         // Assuming Nodes have no more than 32 GPUs
         const int maxDevices = 32;
         int validDevice = 0;


### PR DESCRIPTION
By default, EGLInitialize() (in containers like Docker/Singularity or natively) looks to bind to GPU:0 (first absolute device) on a given machine.

When running MatterSim under HPC (e.g., via SLURM or other job schedulers) that allocate GPU != 0, EGLInitialize fails.

This PR addresses this by looping through all devices visible to current allocated job (SLURM task), and initializing appropriately. No change in the underlying Dockerfile/build process is necessary (`eglext.h` is included by default).