### PR TITLE
chore: upgrade to opencv 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install a few libraries to support both EGL and OSMESA options
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget doxygen curl libjsoncpp-dev libepoxy-dev libglm-dev libosmesa6 libosmesa6-dev libglew-dev libopencv-dev libopencv-dev python3-setuptools python3-dev python3-pip
+RUN apt-get update && apt-get install -y wget doxygen curl libjsoncpp-dev libepoxy-dev libglm-dev libosmesa6 libosmesa6-dev libglew-dev libopencv-dev python3-setuptools python3-dev python3-pip
 RUN pip3 install opencv-python==4.5.3.56 torch==1.4.0 torchvision numpy==1.21.1 pandas==1.3.1 networkx==2.2
 
 #install latest cmake

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,24 +2,23 @@
 # Requires nvidia gpu with driver 396.37 or higher
 
 
-FROM nvidia/cudagl:9.2-devel-ubuntu18.04
+FROM nvidia/cudagl:11.0-devel-ubuntu20.04
 
 # Install cudnn
-ENV CUDNN_VERSION 7.6.4.38
-LABEL com.nvidia.cudnn.version="${CUDNN_VERSION}"
-
+ENV NV_CUDNN_VERSION 8.0.5.39
+ENV NV_CUDNN_PACKAGE "libcudnn8=$NV_CUDNN_VERSION-1+cuda11.0"
+ENV NV_CUDNN_PACKAGE_DEV "libcudnn8-dev=$NV_CUDNN_VERSION-1+cuda11.0"
+ENV NV_CUDNN_PACKAGE_NAME "libcudnn8"
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    libcudnn7=$CUDNN_VERSION-1+cuda9.2 \
-libcudnn7-dev=$CUDNN_VERSION-1+cuda9.2 \
-&& \
-    apt-mark hold libcudnn7 && \
+    ${NV_CUDNN_PACKAGE} \
+    ${NV_CUDNN_PACKAGE_DEV} \
+    && apt-mark hold ${NV_CUDNN_PACKAGE_NAME} && \
     rm -rf /var/lib/apt/lists/*
-
 
 # Install a few libraries to support both EGL and OSMESA options
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget doxygen curl libjsoncpp-dev libepoxy-dev libglm-dev libosmesa6 libosmesa6-dev libglew-dev libopencv-dev python-opencv python3-setuptools python3-dev python3-pip
-RUN pip3 install opencv-python==4.1.0.25 torch==1.1.0 torchvision==0.3.0 numpy==1.13.3 pandas==0.24.1 networkx==2.2
+RUN apt-get update && apt-get install -y wget doxygen curl libjsoncpp-dev libepoxy-dev libglm-dev libosmesa6 libosmesa6-dev libglew-dev libopencv-dev libopencv-dev python3-setuptools python3-dev python3-pip
+RUN pip3 install opencv-python==4.5.3.56 torch==1.4.0 torchvision numpy==1.21.1 pandas==1.3.1 networkx==2.2
 
 #install latest cmake
 ADD https://cmake.org/files/v3.12/cmake-3.12.2-Linux-x86_64.sh /cmake-3.12.2-Linux-x86_64.sh

--- a/src/lib/NavGraph.cpp
+++ b/src/lib/NavGraph.cpp
@@ -56,7 +56,7 @@ void NavGraph::Location::loadCubemapImages() {
     }
     if (includeDepth) {
         // 16 bit grayscale images
-        cv::Mat depth = cv::imread(skyboxDir + viewpointId + "_skybox_depth_small.png", CV_LOAD_IMAGE_ANYDEPTH);
+        cv::Mat depth = cv::imread(skyboxDir + viewpointId + "_skybox_depth_small.png", cv::IMREAD_ANYDEPTH);
         w = depth.cols/6;
         h = depth.rows;
         xposD = depth(cv::Rect(2*w, 0, w, h));

--- a/src/test/main.cpp
+++ b/src/test/main.cpp
@@ -376,7 +376,7 @@ TEST_CASE( "RGB Image", "[Rendering]" ) {
             auto imgfile = testcase["reference_image"].asString();
             auto reference_image = cv::imread("webgl_imgs/"+imgfile);
             auto state = sim.getState().at(n);
-            double err = cv::norm(reference_image, state->rgb, CV_L2);
+            double err = cv::norm(reference_image, state->rgb, cv::NORM_L2);
             err /= reference_image.rows * reference_image.cols;
             CHECK(err < 0.15);
             // save for later comparison, these images can also be inspected by hand


### PR DESCRIPTION
As described to the issue https://github.com/peteanderson80/Matterport3DSimulator/issues/80, we can easily upgrade the code to OpenCV 4.

OpenCV 4 is delivered by default in Ubuntu 20.04, and I updated the Dockerfile accordingly.

I observed I was often using the script linked in the issue and reproduced below. So why not creating a PR since it could ease the installation. 

```bash
#!/bin/sh

find .  \( -name '*.cpp' -or -name '*.hpp' -or -name '*.h' \)  \
  -exec sed -i \
  -e 's/CV_IMWRITE_/cv::IMWRITE_/g' \
  -e 's/CV_LOAD_IMAGE_ANYDEPTH/cv::IMREAD_ANYDEPTH/g' \
  -e 's/CV_LOAD_IMAGE_COLOR/cv::IMREAD_COLOR/g' \
  -e 's/CV_L2/cv::NORM_L2/g' \
  -e 's/CV_TERMCRIT_EPS/cv::TermCriteria::EPS/g' \
  -e 's/CV_TERMCRIT_ITER/cv::TermCriteria::MAX_ITER/g' \
  -e 's/CV_CALIB_CB_/cv::CALIB_CB_/g' \
  -e 's/CV_BGR2GRAY/cv::COLOR_BGR2GRAY/g' \
  -e 's/CV_GRAY2BGR/cv::COLOR_GRAY2BGR/g' \
  -e 's/CV_HAAR_/cv::CASCADE_/g' \
  -e 's/CV_INTER_/cv::INTER_/g' \
  -e 's/CV_WARP_INVERSE_MAP/cv::WARP_INVERSE_MAP/g' \
  -e 's/CV_WINDOW_/cv::WINDOW_/g' \
  -e 's/CV_WND_/cv::WND_/g' \
  -e 's/CV_CAP_/cv::CAP_/g' \
  -e 's/CV_FOURCC/cv::VideoWriter::fourcc/g' \
  '{}' ';'
```